### PR TITLE
[WCM] Use the tab features of SonataAdminBundle 2.3

### DIFF
--- a/Admin/PageAdmin.php
+++ b/Admin/PageAdmin.php
@@ -52,22 +52,28 @@ class PageAdmin extends RouteAdmin
         $formMapper->remove('options');
 
         $formMapper
-            ->with('form.group_general', array(
-                'translation_domain' => 'CmfSimpleCmsBundle',
-            ))
-                ->add('label', null, array('required' => false))
-                ->add('title')
-                ->add('body', 'textarea')
+            ->tab('form.tab_general')
+                ->with('form.group_general', array(
+                    'class' => 'col-md-9',
+                    'translation_domain' => 'CmfSimpleCmsBundle',
+                ))
+                    ->add('label', null, array('required' => false))
+                    ->add('title')
+                    ->add('body', 'textarea', array(
+                        'attr' => array('style' => 'height:200px;'),
+                    ))
+                ->end()
             ->end()
-            ->with('form.group_advanced', array(
-                'translation_domain' => 'CmfRoutingBundle',
-            ))
-                ->add(
-                    'routeOptions',
-                    'sonata_type_immutable_array',
-                    array('keys' => $this->configureFieldsForOptions($this->getSubject()->getRouteOptions()), 'label' => 'form.label_options'),
-                    array('help' => 'form.help_options')
-                )
+
+            ->tab('form.tab_routing')
+                ->with('form.group_path')
+                    ->add(
+                        'routeOptions',
+                        'sonata_type_immutable_array',
+                        array('keys' => $this->configureFieldsForOptions($this->getSubject()->getRouteOptions()), 'label' => 'form.label_options'),
+                        array('help' => 'form.help_options')
+                    )
+                ->end()
             ->end()
         ;
     }

--- a/Resources/translations/CmfSimpleCmsBundle.cs.xliff
+++ b/Resources/translations/CmfSimpleCmsBundle.cs.xliff
@@ -50,9 +50,9 @@
         <source>filter.label_name</source>
         <target>Název</target>
       </trans-unit>
-      <trans-unit id="form.group_general">
-        <source>form.group_general</source>
-        <target>Obecné</target>
+      <trans-unit id="form.group_content">
+        <source>form.group_content</source>
+        <target>Obsah</target>
       </trans-unit>
       <trans-unit id="form.label_parent">
         <source>form.label_parent</source>

--- a/Resources/translations/CmfSimpleCmsBundle.de.xliff
+++ b/Resources/translations/CmfSimpleCmsBundle.de.xliff
@@ -1,83 +1,83 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
-    <body>
-      <trans-unit id="dashboard.cmf">
-        <source>dashboard.cmf</source>
-        <target>Symfony CMF</target>
-      </trans-unit>
-      <trans-unit id="dashboard.label_page">
-        <source>dashboard.label_page</source>
-        <target>Seiten</target>
-      </trans-unit>
-      <trans-unit id="breadcrumb.link_page_list">
-        <source>breadcrumb.link_page_list</source>
-        <target>Seiten</target>
-      </trans-unit>
-      <trans-unit id="breadcrumb.link_page_create">
-        <source>breadcrumb.link_page_create</source>
-        <target>Erstellen</target>
-      </trans-unit>
-      <trans-unit id="breadcrumb.link_page_edit">
-        <source>breadcrumb.link_page_edit</source>
-        <target>Bearbeiten</target>
-      </trans-unit>
-      <trans-unit id="breadcrumb.link_page_delete">
-        <source>breadcrumb.link_page_delete</source>
-        <target>Löschen</target>
-      </trans-unit>
-      <trans-unit id="list.label_path">
-        <source>list.label_path</source>
-        <target>Pfad</target>
-      </trans-unit>
-      <trans-unit id="list.label_title">
-        <source>list.label_title</source>
-        <target>Titel</target>
-      </trans-unit>
-      <trans-unit id="list.label_name">
-        <source>list.label_name</source>
-        <target>Name</target>
-      </trans-unit>
-      <trans-unit id="list.label_label">
-        <source>list.label_label</source>
-        <target>Label</target>
-      </trans-unit>
-      <trans-unit id="list.label_create_date">
-        <source>list.label_create_date</source>
-        <target>Erstellungsdatum</target>
-      </trans-unit>
-      <trans-unit id="filter.label_title">
-        <source>filter.label_title</source>
-        <target>Titel</target>
-      </trans-unit>
-      <trans-unit id="filter.label_name">
-        <source>filter.label_name</source>
-        <target>Name</target>
-      </trans-unit>
-      <trans-unit id="form.group_general">
-        <source>form.group_general</source>
-        <target>Allgemein</target>
-      </trans-unit>
-      <trans-unit id="form.label_parent">
-        <source>form.label_parent</source>
-        <target>Übergeordnet</target>
-      </trans-unit>
-      <trans-unit id="form.label_name">
-        <source>form.label_name</source>
-        <target>Name</target>
-      </trans-unit>
-      <trans-unit id="form.label_label">
-        <source>form.label_label</source>
-        <target>Menüname</target>
-      </trans-unit>
-      <trans-unit id="form.label_title">
-        <source>form.label_title</source>
-        <target>Titel</target>
-      </trans-unit>
-      <trans-unit id="form.label_body">
-        <source>form.label_body</source>
-        <target>Inhalt</target>
-	</trans-unit>
-    </body>
-  </file>
+    <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="dashboard.cmf">
+                <source>dashboard.cmf</source>
+                <target>Symfony CMF</target>
+            </trans-unit>
+            <trans-unit id="dashboard.label_page">
+                <source>dashboard.label_page</source>
+                <target>Seiten</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_page_list">
+                <source>breadcrumb.link_page_list</source>
+                <target>Seiten</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_page_create">
+                <source>breadcrumb.link_page_create</source>
+                <target>Erstellen</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_page_edit">
+                <source>breadcrumb.link_page_edit</source>
+                <target>Bearbeiten</target>
+            </trans-unit>
+            <trans-unit id="breadcrumb.link_page_delete">
+                <source>breadcrumb.link_page_delete</source>
+                <target>Löschen</target>
+            </trans-unit>
+            <trans-unit id="list.label_path">
+                <source>list.label_path</source>
+                <target>Pfad</target>
+            </trans-unit>
+            <trans-unit id="list.label_title">
+                <source>list.label_title</source>
+                <target>Titel</target>
+            </trans-unit>
+            <trans-unit id="list.label_name">
+                <source>list.label_name</source>
+                <target>Name</target>
+            </trans-unit>
+            <trans-unit id="list.label_label">
+                <source>list.label_label</source>
+                <target>Label</target>
+            </trans-unit>
+            <trans-unit id="list.label_create_date">
+                <source>list.label_create_date</source>
+                <target>Erstellungsdatum</target>
+            </trans-unit>
+            <trans-unit id="filter.label_title">
+                <source>filter.label_title</source>
+                <target>Titel</target>
+            </trans-unit>
+            <trans-unit id="filter.label_name">
+                <source>filter.label_name</source>
+                <target>Name</target>
+            </trans-unit>
+            <trans-unit id="form.group_content">
+                <source>form.group_content</source>
+                <target>Inhalt</target>
+            </trans-unit>
+            <trans-unit id="form.label_parent">
+                <source>form.label_parent</source>
+                <target>Übergeordnet</target>
+            </trans-unit>
+            <trans-unit id="form.label_name">
+                <source>form.label_name</source>
+                <target>Name</target>
+            </trans-unit>
+            <trans-unit id="form.label_label">
+                <source>form.label_label</source>
+                <target>Menüname</target>
+            </trans-unit>
+            <trans-unit id="form.label_title">
+                <source>form.label_title</source>
+                <target>Titel</target>
+            </trans-unit>
+            <trans-unit id="form.label_body">
+                <source>form.label_body</source>
+                <target>Inhalt</target>
+            </trans-unit>
+        </body>
+    </file>
 </xliff>

--- a/Resources/translations/CmfSimpleCmsBundle.en.xliff
+++ b/Resources/translations/CmfSimpleCmsBundle.en.xliff
@@ -52,7 +52,7 @@
       </trans-unit>
       <trans-unit id="form.group_general">
         <source>form.group_general</source>
-        <target>General</target>
+        <target>Page</target>
       </trans-unit>
       <trans-unit id="form.label_parent">
         <source>form.label_parent</source>

--- a/Resources/translations/CmfSimpleCmsBundle.fr.xliff
+++ b/Resources/translations/CmfSimpleCmsBundle.fr.xliff
@@ -50,9 +50,9 @@
         <source>filter.label_name</source>
         <target>Nom</target>
       </trans-unit>
-      <trans-unit id="form.group_general">
-        <source>form.group_general</source>
-        <target>Général</target>
+      <trans-unit id="form.group_content">
+        <source>form.group_content</source>
+        <target>Contenu</target>
       </trans-unit>
       <trans-unit id="form.label_parent">
         <source>form.label_parent</source>

--- a/Resources/translations/CmfSimpleCmsBundle.sk.xliff
+++ b/Resources/translations/CmfSimpleCmsBundle.sk.xliff
@@ -54,9 +54,9 @@
         <source>filter.label_name</source>
         <target>Názov</target>
       </trans-unit>
-      <trans-unit id="form.group_general">
-        <source>form.group_general</source>
-        <target>Všeobecné</target>
+      <trans-unit id="form.group_content">
+        <source>form.group_content</source>
+        <target>Obsah</target>
       </trans-unit>
       <trans-unit id="form.label_parent">
         <source>form.label_parent</source>

--- a/Resources/translations/CmfSimpleCmsBundle.sl.xliff
+++ b/Resources/translations/CmfSimpleCmsBundle.sl.xliff
@@ -50,9 +50,9 @@
         <source>filter.label_name</source>
         <target>Ime</target>
       </trans-unit>
-      <trans-unit id="form.group_general">
-        <source>form.group_general</source>
-        <target>Splošno</target>
+      <trans-unit id="form.group_content">
+        <source>form.group_content</source>
+        <target>Vsebina</target>
       </trans-unit>
       <trans-unit id="form.label_parent">
         <source>form.label_parent</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This should also work under SonataAdminBundle <2.3. This'll use both groups (columns) and tabs in the admin panel, improving the UX a lot :)

A screenshot of the result (also using the new tree btw):

![cmf-simple-cms-admin](https://cloud.githubusercontent.com/assets/749025/5805944/3c228270-a014-11e4-99c9-6486b05f78c2.png)

This requires https://github.com/sonata-project/SonataAdminBundle/pull/2615 and https://github.com/symfony-cmf/RoutingBundle/pull/284 to be merged.